### PR TITLE
feat: Add Banzai Cloud Kafka operator repo

### DIFF
--- a/helm-repositories/banzaicloud/banzaicloud.yaml
+++ b/helm-repositories/banzaicloud/banzaicloud.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: kubernetes-charts.banzaicloud.com
+spec:
+  url: https://kubernetes-charts.banzaicloud.com
+  interval: 10m

--- a/helm-repositories/banzaicloud/kustomization.yaml
+++ b/helm-repositories/banzaicloud/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - banzaicloud.yaml


### PR DESCRIPTION
Adding the banzai cloud helm repo, for now I kept it specific to the Kafka operator but maybe it should named more generally so it can be reused for other charts in that repo?