### PR TITLE
fix: Add namespace in helmreleases

### DIFF
--- a/services/kafka-operator/0.20.0/kafka-operator.yaml
+++ b/services/kafka-operator/0.20.0/kafka-operator.yaml
@@ -11,6 +11,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: kubernetes-charts.banzaicloud.com
+        namespace: ${workspaceNamespace}
       version: 0.20.0
   interval: 15s
   install:

--- a/services/spark-operator/1.1.6/spark-operator.yaml
+++ b/services/spark-operator/1.1.6/spark-operator.yaml
@@ -11,6 +11,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: mesosphere.github.io-spark-charts
+        namespace: ${workspaceNamespace}
       version: 1.1.6
   interval: 15s
   install:

--- a/services/zookeeper-operator/0.2.13/zookeeper-operator.yaml
+++ b/services/zookeeper-operator/0.2.13/zookeeper-operator.yaml
@@ -11,6 +11,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: charts.pravega.io
+        namespace: ${workspaceNamespace}
       version: 0.2.13
   interval: 15s
   install:


### PR DESCRIPTION
Adding the `HelmRepository` namespace to the `HelmRelease` objects to allow bundle creation via k-cli. This should be a noop, but the bundle creation process requires this.