### PR TITLE
chore: add label to allow dynamic secret injection

### DIFF
--- a/helm-repositories/banzaicloud/banzaicloud.yaml
+++ b/helm-repositories/banzaicloud/banzaicloud.yaml
@@ -4,6 +4,8 @@ kind: HelmRepository
 metadata:
   name: kubernetes-charts.banzaicloud.com
   namespace: ${workspaceNamespace}
+  labels:
+    kommander.d2iq.io/dkp-airgapped: supported
 spec:
   url: "${helmMirrorURL:=https://kubernetes-charts.banzaicloud.com}"
   interval: 10m

--- a/helm-repositories/mesosphere-spark-repo/mesosphere-spark-repo.yaml
+++ b/helm-repositories/mesosphere-spark-repo/mesosphere-spark-repo.yaml
@@ -4,6 +4,8 @@ kind: HelmRepository
 metadata:
   name: mesosphere.github.io-spark-charts
   namespace: ${workspaceNamespace}
+  labels:
+    kommander.d2iq.io/dkp-airgapped: supported
 spec:
   url: "${helmMirrorURL:=http://mesosphere.github.io/spark-on-k8s-operator}"
   interval: 10m

--- a/helm-repositories/pravega/pravega.yaml
+++ b/helm-repositories/pravega/pravega.yaml
@@ -4,6 +4,8 @@ kind: HelmRepository
 metadata:
   name: charts.pravega.io
   namespace: ${workspaceNamespace}
+  labels:
+    kommander.d2iq.io/dkp-airgapped: supported
 spec:
   url: "${helmMirrorURL:=https://charts.pravega.io}"
   interval: 10m

--- a/services/kafka-operator/metadata.yaml
+++ b/services/kafka-operator/metadata.yaml
@@ -2,6 +2,9 @@ displayName: Kafka Operator
 description: Koperator is an operator for managing Apache Kafka on Kubernetes that automates the provisioning, management, and autoscaling of Apache Kafka clusters deployed to K8s.
 category:
   - Data Services
+certifications:
+  - certified
+  - airgapped
 scope:
   - workspace
 overview: |-

--- a/services/spark-operator/metadata.yaml
+++ b/services/spark-operator/metadata.yaml
@@ -2,6 +2,9 @@ displayName: Spark Operator
 description: Spark Operator uses Kubernetes custom resources for specifying, running, and surfacing status of Spark applications.
 category:
   - Data Services
+certifications:
+  - certified
+  - airgapped
 scope:
   - workspace
 overview: |-

--- a/services/zookeeper-operator/metadata.yaml
+++ b/services/zookeeper-operator/metadata.yaml
@@ -2,6 +2,9 @@ displayName: ZooKeeper Operator
 description: The ZooKeeper operator deploys Zookeeper 3.6.3 clusters, and uses Zookeeper dynamic reconfiguration to handle node membership.
 category:
   - Data Services
+certifications:
+  - certified
+  - airgapped
 scope:
   - workspace
 overview: |-


### PR DESCRIPTION
Label HelmRepositories to support helmMirrorUrl substitution.

See https://github.com/mesosphere/kommander/pull/1534 for why this change is needed