### PR TITLE
build: Add missing zk image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ GOJQ_VERSION ?= v0.12.4
 export GOJQ_BIN = bin/$(GOOS)/$(GOARCH)/gojq-$(GOJQ_VERSION)
 export MINDTHEGAP_BIN = bin/$(GOOS)/$(GOARCH)/mindthegap
 
+ifneq (,$(filter tar (GNU tar)%, $(shell tar --version)))
+WILDCARDS := --wildcards
+endif
+
 ifneq ($(wildcard $(REPO_ROOT)/.pre-commit-config.yaml),)
 	PRE_COMMIT_CONFIG_FILE ?= $(REPO_ROOT)/.pre-commit-config.yaml
 else

--- a/hack/images.yaml
+++ b/hack/images.yaml
@@ -20,3 +20,4 @@ zookeeper-0.2.13:
   - "docker.io/pravega/zookeeper-operator:0.2.13"
   - "docker.io/pravega/zookeeper:0.2.13"
   - "docker.io/pravega/zookeeper:0.2.12"
+  - "docker.io/lachlanevenson/k8s-kubectl:v1.16.10"

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -21,7 +21,7 @@ endif
 $(GOJQ_BIN):
 	$(call print-target)
 	mkdir -p $(dir $@) _install
-	curl -fsSL https://github.com/itchyny/gojq/releases/download/$(GOJQ_VERSION)/gojq_$(GOJQ_VERSION)_$(GOOS)_$(GOARCH).$(GOJQ_EXT) | tar xz -C _install --wildcards --strip-components 1 '*/gojq'
+	curl -fsSL https://github.com/itchyny/gojq/releases/download/$(GOJQ_VERSION)/gojq_$(GOJQ_VERSION)_$(GOOS)_$(GOARCH).$(GOJQ_EXT) | tar xz -C _install $(WILDCARDS) --strip-components 1 '*/gojq'
 	mv _install/gojq $@
 	chmod 755 $@
 	rm -rf _install


### PR DESCRIPTION
Adding a missing image for the zookeeper operator that is used by a post-install job.

Also, just a minor fix for running some make targets on Mac.