### PR TITLE
build: Make image bundle release name consistent

### DIFF
--- a/make/release.mk
+++ b/make/release.mk
@@ -22,5 +22,5 @@ release.s3:
 ifeq ($(CATALOG_APPLICATIONS_VERSION),"")
 	$(info CATALOG_APPLICATIONS_VERSION should be set to the version which is part of the s3 file path)
 else
-	aws s3 cp --no-progress --acl bucket-owner-full-control $(IMAGE_TAR_FILE) s3://$(RELEASE_S3_BUCKET)/dkp/$(CATALOG_APPLICATIONS_VERSION)/catalog_applications_image_bundle_$(CATALOG_APPLICATIONS_VERSION)_linux_amd64.tar.gz
+	aws s3 cp --no-progress --acl bucket-owner-full-control $(IMAGE_TAR_FILE) s3://$(RELEASE_S3_BUCKET)/dkp/$(CATALOG_APPLICATIONS_VERSION)/catalog-applications-image-bundle-$(CATALOG_APPLICATIONS_VERSION).tar.gz
 endif

--- a/make/release.mk
+++ b/make/release.mk
@@ -22,5 +22,5 @@ release.s3:
 ifeq ($(CATALOG_APPLICATIONS_VERSION),"")
 	$(info CATALOG_APPLICATIONS_VERSION should be set to the version which is part of the s3 file path)
 else
-	aws s3 cp --no-progress --acl bucket-owner-full-control $(IMAGE_TAR_FILE) s3://$(RELEASE_S3_BUCKET)/dkp/$(CATALOG_APPLICATIONS_VERSION)/catalog-applications-image-bundle-$(CATALOG_APPLICATIONS_VERSION).tar.gz
+	aws s3 cp --no-progress --acl bucket-owner-full-control $(IMAGE_TAR_FILE) s3://$(RELEASE_S3_BUCKET)/dkp/$(CATALOG_APPLICATIONS_VERSION)/dkp-catalog-applications-image-bundle-$(CATALOG_APPLICATIONS_VERSION).tar.gz
 endif


### PR DESCRIPTION
Updating the actual image bundle name according to https://github.com/mesosphere/kommander/pull/1605/files#diff-70acc2689fb0b36f116699b4dd558c7361f4cc683cd8a4dd6f1e559a76e9a674R159