### PR TITLE
build: remove prefix on the git archive

### DIFF
--- a/make/release.mk
+++ b/make/release.mk
@@ -23,7 +23,6 @@ ifeq ($(CATALOG_APPLICATIONS_VERSION),"")
 	$(info CATALOG_APPLICATIONS_VERSION should be set to the version which is part of the s3 file path)
 else
 	git archive --format "tar.gz" -o $(REPO_ARCHIVE_FILE) \
-	                              --prefix dkp-catalog-applications/ \
 	                              $(CATALOG_APPLICATIONS_VERSION) -- \
 	                              helm-repositories services
 endif


### PR DESCRIPTION
After testing this locally, it looks like in order to use the tar directly in the CLI config we'll need to remove the prefix.
