### PR TITLE
build: Add chart bundle release targets

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -18,4 +18,6 @@ ARG DOCKER_VERSION
 RUN curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz | \
     tar xz -C /usr/local/bin --strip-components=1 docker/docker
 
+# needed to be able to pull private repos, e.g. in 'go mod download'
+RUN git config --global url."git@github.com:".insteadOf "https://github.com/"
 RUN mkdir -p ~/.ssh && echo 'github.com,140.82.118.4 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' > ~/.ssh/known_hosts

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,23 @@
 .DEFAULT_GOAL := help
 
 SHELL := /bin/bash -euo pipefail
-
 REPO_ROOT := $(CURDIR)
-
 INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 
+export GOPRIVATE ?= github.com/mesosphere
 export GITHUB_ORG ?= mesosphere
 export GITHUB_REPOSITORY ?= dkp-catalog-applications
+export GOBIN := $(REPO_ROOT)/bin/$(GOOS)/$(GOARCH)
+export PATH := $(GOBIN):$(PATH)
 GOARCH ?= $(shell go env GOARCH)
 GOOS ?= $(shell go env GOOS)
+
 MINDTHEGAP_VERSION ?= v0.13.1
 GOJQ_VERSION ?= v0.12.4
+KOMMANDER_CLI_VERSION ?= main
 export GOJQ_BIN = bin/$(GOOS)/$(GOARCH)/gojq-$(GOJQ_VERSION)
 export MINDTHEGAP_BIN = bin/$(GOOS)/$(GOARCH)/mindthegap
+export KOMMANDER_CLI_BIN = bin/kommander-cli
 
 ifneq (,$(filter tar (GNU tar)%, $(shell tar --version)))
 WILDCARDS := --wildcards
@@ -49,3 +53,8 @@ endef
 
 .PHONY: test
 test: validate-manifests
+
+.PHONY: clean
+clean:
+	$(call print-target)
+	@rm -rf bin _build

--- a/make/release.mk
+++ b/make/release.mk
@@ -1,6 +1,7 @@
 BUILD_DIR := _build
 IMAGE_TAR_FILE := $(BUILD_DIR)/dkp-catalog-applications-image-bundle.tar.gz
 REPO_ARCHIVE_FILE := $(BUILD_DIR)/dkp-catalog-applications.tar.gz
+CHART_BUNDLE := $(BUILD_DIR)/dkp-catalog-applications-chart-bundle.tar.gz
 CATALOG_IMAGES_TXT := $(BUILD_DIR)/dkp_catalog_images.txt
 RELEASE_S3_BUCKET ?= downloads.mesosphere.io
 
@@ -27,12 +28,21 @@ else
 	                              helm-repositories services
 endif
 
+.PHONY: release.chart-bundle
+release.chart-bundle: kommander-cli
+	$(call print-target)
+	echo "Building charts bundle from dkp-catalog-applications repository: "
+	$(KOMMANDER_CLI_BIN) create chart-bundle \
+		--catalog-repository $(REPO_ROOT) \
+		--output $(CHART_BUNDLE)
+
 .PHONY: release.s3
 release.s3:
 	$(call print-target)
 ifeq ($(CATALOG_APPLICATIONS_VERSION),"")
 	$(info CATALOG_APPLICATIONS_VERSION should be set to the version which is part of the s3 file path)
 else
+	aws s3 cp --no-progress --acl bucket-owner-full-control $(CHART_BUNDLE) s3://$(RELEASE_S3_BUCKET)/dkp/$(CATALOG_APPLICATIONS_VERSION)/dkp-catalog-applications-charts-bundle-$(CATALOG_APPLICATIONS_VERSION).tar.gz
 	aws s3 cp --no-progress --acl bucket-owner-full-control $(REPO_ARCHIVE_FILE) s3://$(RELEASE_S3_BUCKET)/dkp/$(CATALOG_APPLICATIONS_VERSION)/dkp-catalog-applications-$(CATALOG_APPLICATIONS_VERSION).tar.gz
 	aws s3 cp --no-progress --acl bucket-owner-full-control $(IMAGE_TAR_FILE) s3://$(RELEASE_S3_BUCKET)/dkp/$(CATALOG_APPLICATIONS_VERSION)/dkp-catalog-applications-image-bundle-$(CATALOG_APPLICATIONS_VERSION).tar.gz
 endif

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -25,3 +25,8 @@ $(GOJQ_BIN):
 	mv _install/gojq $@
 	chmod 755 $@
 	rm -rf _install
+
+.PHONY: kommander-cli
+kommander-cli:
+	$(call print-target)
+	CGO_ENABLED=0 go install github.com/mesosphere/kommander-cli/v2@$(KOMMANDER_CLI_VERSION)


### PR DESCRIPTION
This PR adds the chart bundle release (removed from the kommander repo in https://github.com/mesosphere/kommander/pull/1682).

