### PR TITLE
build: add validation against multiple Kubernetes versions

### DIFF
--- a/.bloodhound.yml
+++ b/.bloodhound.yml
@@ -15,6 +15,7 @@ strict: true
 
 # types to be skipped (e.g. certmanager.k8s.io/v1, or certmanager.k8s.io/v1/Certificate)
 skip_types:
+  # Flux types are installed by Kommander, not included in this repository
   - source.toolkit.fluxcd.io/v1beta1/HelmRepository
 
 # load additional CRDs (URLs of CRD yaml files)

--- a/.bloodhound.yml
+++ b/.bloodhound.yml
@@ -14,12 +14,12 @@ paths:
 strict: true
 
 # types to be skipped (e.g. certmanager.k8s.io/v1, or certmanager.k8s.io/v1/Certificate)
-skip_types:
-  # Flux types are installed by Kommander, not included in this repository
-  - source.toolkit.fluxcd.io/v1beta1/HelmRepository
+skip_types: []
 
 # load additional CRDs (URLs of CRD yaml files)
-additional_crds: []
+additional_crds:
+  # Flux types are installed by Kommander, not included in this repository
+  - https://github.com/fluxcd/source-controller/releases/download/v0.24.4/source-controller.crds.yaml
 
 # set values for substitution variables (e.g. ${releaseNamespace}) in the resources
 substitution_vars:

--- a/.bloodhound.yml
+++ b/.bloodhound.yml
@@ -1,0 +1,26 @@
+# Kubernetes versions
+# (e.g. 1.23.0 - has to match versions in https://github.com/yannh/kubernetes-json-schema)
+k8s_versions:
+  - 1.21.0
+  - 1.22.0
+  - 1.23.6
+
+# paths to load (in that order)
+paths:
+  - helm-repositories
+  - services
+
+# use strict validation (reject unknown fields in resources)
+strict: true
+
+# types to be skipped (e.g. certmanager.k8s.io/v1, or certmanager.k8s.io/v1/Certificate)
+skip_types:
+  - source.toolkit.fluxcd.io/v1beta1/HelmRepository
+
+# load additional CRDs (URLs of CRD yaml files)
+additional_crds: []
+
+# set values for substitution variables (e.g. ${releaseNamespace}) in the resources
+substitution_vars:
+  releaseNamespace: kommander
+  workspaceNamespace: workspace

--- a/make/validate.mk
+++ b/make/validate.mk
@@ -1,5 +1,5 @@
-DKP_BLOODHOUND_VERSION ?= 0.2.1
-DKP_BLOODHOUND_BIN := $(LOCAL_DIR)/bin/dkp-bloodhound_v$(DKP_BLOODHOUND_VERSION)
+DKP_BLOODHOUND_VERSION ?= 0.5.0
+DKP_BLOODHOUND_BIN := bin/dkp-bloodhound_v$(DKP_BLOODHOUND_VERSION)
 
 $(DKP_BLOODHOUND_BIN):
 	mkdir -p `dirname $@`
@@ -8,4 +8,4 @@ $(DKP_BLOODHOUND_BIN):
 
 .PHONY: validate-manifests
 validate-manifests: $(DKP_BLOODHOUND_BIN)
-	$(DKP_BLOODHOUND_BIN) . --helm-repo-path ./helm-repositories
+	$(DKP_BLOODHOUND_BIN)


### PR DESCRIPTION
Validates the manifests against different Kubernetes versions, configurable in `.bloodhound.yml`.

Jira: https://jira.d2iq.com/browse/D2IQ-88981