### PR TITLE
ci: Use go1.19 (#78)

### DIFF
--- a/make/ci.mk
+++ b/make/ci.mk
@@ -6,7 +6,7 @@ CI_DOCKER_TAG ?= $(shell (cat $(CI_DOCKERFILE) $(CI_DOCKER_EXTRA_FILES) \
                          | shasum | awk '{ print $$1 }')
 CI_DOCKER_IMG ?= $(GITHUB_ORG)/$(GITHUB_REPOSITORY)-ci:$(CI_DOCKER_TAG)
 
-export GOLANG_VERSION ?= 1.17.0
+export GOLANG_VERSION ?= 1.19.1
 DOCKER_VERSION ?= 20.10.7
 
 .PHONY: dockerauth

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -29,4 +29,6 @@ $(GOJQ_BIN):
 .PHONY: kommander-cli
 kommander-cli:
 	$(call print-target)
-	CGO_ENABLED=0 go install github.com/mesosphere/kommander-cli/v2@$(KOMMANDER_CLI_VERSION)
+	go install golang.org/dl/go1.19@latest
+	go1.19 download
+	CGO_ENABLED=0 go1.19 install github.com/mesosphere/kommander-cli/v2@$(KOMMANDER_CLI_VERSION)


### PR DESCRIPTION
release job is using kcli at main which bumped go to 1.19.