### PR TITLE
feat: Add kafka-operator v0.23.0-dev.0

### DIFF
--- a/make/validate.mk
+++ b/make/validate.mk
@@ -3,7 +3,7 @@ DKP_BLOODHOUND_BIN := bin/dkp-bloodhound_v$(DKP_BLOODHOUND_VERSION)
 
 $(DKP_BLOODHOUND_BIN):
 	mkdir -p `dirname $@`
-	curl -fsSL https://downloads.mesosphere.io/dkp-bloodhound/dkp-bloodhound_v$(DKP_BLOODHOUND_VERSION)_linux_amd64.tar.gz | tar xz -O > $@
+	curl -fsSL https://downloads.d2iq.com/dkp-bloodhound/dkp-bloodhound_v$(DKP_BLOODHOUND_VERSION)_linux_amd64.tar.gz | tar xz -O > $@
 	chmod +x $@
 
 .PHONY: validate-manifests

--- a/services/kafka-operator/0.20.0/metadata.yaml
+++ b/services/kafka-operator/0.20.0/metadata.yaml
@@ -1,1 +1,1 @@
-k8sVersionSupport: ">=1.19"
+k8sVersionSupport: "1.19 - 1.24.x"

--- a/services/kafka-operator/0.20.2/metadata.yaml
+++ b/services/kafka-operator/0.20.2/metadata.yaml
@@ -1,1 +1,1 @@
-k8sVersionSupport: ">=1.20"
+k8sVersionSupport: ">=1.20 - 1.24.x"

--- a/services/kafka-operator/0.20.2/metadata.yaml
+++ b/services/kafka-operator/0.20.2/metadata.yaml
@@ -1,1 +1,1 @@
-k8sVersionSupport: ">=1.20 - 1.24.x"
+k8sVersionSupport: "1.20 - 1.24.x"

--- a/services/kafka-operator/0.23.0-dev.0/defaults/cm.yaml
+++ b/services/kafka-operator/0.23.0-dev.0/defaults/cm.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kafka-operator-0.23.0-dev.0-d2iq-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: |
+    ---
+    certManager:
+      enabled: true
+    crd:
+      enabled: true

--- a/services/kafka-operator/0.23.0-dev.0/defaults/kustomization.yaml
+++ b/services/kafka-operator/0.23.0-dev.0/defaults/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml

--- a/services/kafka-operator/0.23.0-dev.0/kafka-operator.yaml
+++ b/services/kafka-operator/0.23.0-dev.0/kafka-operator.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: kafka-operator
+  namespace: ${releaseNamespace}
+spec:
+  chart:
+    spec:
+      chart: kafka-operator
+      sourceRef:
+        kind: HelmRepository
+        name: kubernetes-charts.banzaicloud.com
+        namespace: ${workspaceNamespace}
+      version: 0.23.0-dev.0
+  interval: 15s
+  install:
+    remediation:
+      retries: 30
+    createNamespace: true
+  upgrade:
+    remediation:
+      retries: 30
+  releaseName: kafka-operator
+  valuesFrom:
+    - kind: ConfigMap
+      name: kafka-operator-0.23.0-dev.0-d2iq-defaults
+  targetNamespace: ${releaseNamespace}

--- a/services/kafka-operator/0.23.0-dev.0/kustomization.yaml
+++ b/services/kafka-operator/0.23.0-dev.0/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kafka-operator.yaml
+  - ../../../helm-repositories/banzaicloud

--- a/services/kafka-operator/0.23.0-dev.0/metadata.yaml
+++ b/services/kafka-operator/0.23.0-dev.0/metadata.yaml
@@ -1,0 +1,1 @@
+k8sVersionSupport: ">=1.25"


### PR DESCRIPTION
https://d2iq.atlassian.net/browse/D2IQ-95258

Adds the latest dev version of kafka-operator https://github.com/banzaicloud/koperator/releases/tag/v0.23.0-dev.0 that is compatible with k8s 1.25