### PR TITLE
fix: Use downloads.d2iq.com

### DIFF
--- a/make/validate.mk
+++ b/make/validate.mk
@@ -3,7 +3,7 @@ DKP_BLOODHOUND_BIN := bin/dkp-bloodhound_v$(DKP_BLOODHOUND_VERSION)
 
 $(DKP_BLOODHOUND_BIN):
 	mkdir -p `dirname $@`
-	curl -fsSL https://downloads.mesosphere.io/dkp-bloodhound/dkp-bloodhound_v$(DKP_BLOODHOUND_VERSION)_linux_amd64.tar.gz | tar xz -O > $@
+	curl -fsSL https://downloads.d2iq.com/dkp-bloodhound/dkp-bloodhound_v$(DKP_BLOODHOUND_VERSION)_linux_amd64.tar.gz | tar xz -O > $@
 	chmod +x $@
 
 .PHONY: validate-manifests


### PR DESCRIPTION
Releases are failing on the link being outdated. However, since we have already tagged 2.3.2-rc.2 without that fix, I don't think we can get the release working unless we re-tag with this fix.