### PR TITLE
feat: Add zookeeper-operator 0.2.14

### DIFF
--- a/hack/images.yaml
+++ b/hack/images.yaml
@@ -21,3 +21,8 @@ zookeeper-0.2.13:
   - "docker.io/pravega/zookeeper:0.2.13"
   - "docker.io/pravega/zookeeper:0.2.12"
   - "docker.io/lachlanevenson/k8s-kubectl:v1.16.10"
+zookeeper-0.2.14:
+  - "docker.io/mesosphere/zookeeper-operator:0.2.14-d2iq"
+  - "docker.io/pravega/zookeeper:0.2.14"
+  - "docker.io/pravega/zookeeper:0.2.13"
+  - "docker.io/lachlanevenson/k8s-kubectl:v1.23.2"

--- a/services/zookeeper-operator/0.2.13/metadata.yaml
+++ b/services/zookeeper-operator/0.2.13/metadata.yaml
@@ -1,1 +1,1 @@
-k8sVersionSupport: ">=1.20"
+k8sVersionSupport: "1.20 - 1.24.x"

--- a/services/zookeeper-operator/0.2.14/defaults/cm.yaml
+++ b/services/zookeeper-operator/0.2.14/defaults/cm.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zookeeper-operator-0.2.14-d2iq-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: |-
+    # We forked the zookeeper-operator in order to support k8s 1.25+.
+    # Once https://github.com/pravega/zookeeper-operator/commit/adcf3bf0adaf1aef2c3f0fb89aff8c5bde1e0021
+    # is released, we can move back to the upstream operator image.
+    image:
+      repository: mesosphere/zookeeper-operator
+      tag: 0.2.14-d2iq

--- a/services/zookeeper-operator/0.2.14/defaults/kustomization.yaml
+++ b/services/zookeeper-operator/0.2.14/defaults/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml

--- a/services/zookeeper-operator/0.2.14/kustomization.yaml
+++ b/services/zookeeper-operator/0.2.14/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - zookeeper-operator.yaml
+  - ../../../helm-repositories/pravega

--- a/services/zookeeper-operator/0.2.14/metadata.yaml
+++ b/services/zookeeper-operator/0.2.14/metadata.yaml
@@ -1,0 +1,1 @@
+k8sVersionSupport: ">=1.21"

--- a/services/zookeeper-operator/0.2.14/zookeeper-operator.yaml
+++ b/services/zookeeper-operator/0.2.14/zookeeper-operator.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: zookeeper-operator
+  namespace: ${releaseNamespace}
+spec:
+  chart:
+    spec:
+      chart: zookeeper-operator
+      sourceRef:
+        kind: HelmRepository
+        name: charts.pravega.io
+        namespace: ${workspaceNamespace}
+      version: 0.2.14
+  interval: 15s
+  install:
+    remediation:
+      retries: 30
+    createNamespace: true
+  upgrade:
+    remediation:
+      retries: 30
+  releaseName: zookeeper-operator
+  valuesFrom:
+    - kind: ConfigMap
+      name: zookeeper-operator-0.2.14-d2iq-defaults
+  targetNamespace: ${releaseNamespace}

--- a/services/zookeeper-operator/metadata.yaml
+++ b/services/zookeeper-operator/metadata.yaml
@@ -1,5 +1,5 @@
 displayName: ZooKeeper Operator
-description: The ZooKeeper operator deploys Zookeeper 3.6.3 clusters, and uses Zookeeper dynamic reconfiguration to handle node membership.
+description: The ZooKeeper operator deploys Zookeeper clusters, and uses Zookeeper dynamic reconfiguration to handle node membership.
 allowMultipleInstances: false
 category:
   - Data Services
@@ -12,7 +12,7 @@ overview: |-
   # Overview
   ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.
 
-  The ZooKeeper operator deploys Zookeeper 3.6.3 clusters, and uses Zookeeper dynamic reconfiguration to handle node membership.
+  The ZooKeeper operator deploys Zookeeper clusters, and uses Zookeeper dynamic reconfiguration to handle node membership.
 
   **Note: Only install the ZooKeeper operator once per workspace.**
 


### PR DESCRIPTION
Bumps the zookeeper-operator to chart version `0.2.14` and the image that was built from our fork. 

