### PR TITLE
build: Add kafka images for new version

### DIFF
--- a/hack/images.yaml
+++ b/hack/images.yaml
@@ -16,6 +16,12 @@ kafka-0.20.2:
   - "ghcr.io/banzaicloud/kafka-operator:v0.20.2"
   - "ghcr.io/banzaicloud/cruise-control:2.5.79"
   - "ghcr.io/banzaicloud/kafka:2.13-3.1.0"
+kafka-0.23.0-dev.0:
+  - "ghcr.io/banzaicloud/kafka-operator:v0.23.0-dev.0"
+  - "ghcr.io/banzaicloud/cruise-control:2.5.101"
+  - "ghcr.io/banzaicloud/kafka:2.13-3.1.0"
+  - "ghcr.io/banzaicloud/jmx-javaagent:0.16.1"
+  - "gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0"
 zookeeper-0.2.13:
   - "docker.io/pravega/zookeeper-operator:0.2.13"
   - "docker.io/pravega/zookeeper:0.2.13"


### PR DESCRIPTION
Adding the images from the new kafka-operator version that was added. I installed on the daily and grabbed all the images that were being used. 