### PR TITLE
feat: Update kafka k8s version support

### DIFF
--- a/services/kafka-operator/0.23.0-dev.0/metadata.yaml
+++ b/services/kafka-operator/0.23.0-dev.0/metadata.yaml
@@ -1,1 +1,1 @@
-k8sVersionSupport: ">=1.25"
+k8sVersionSupport: ">=1.21"


### PR DESCRIPTION
The new PDB API is only available in 1.21+, so this version of the kafka operator will work on k8s >=1.21 