### PR TITLE
feat: Bump Kafka operator to v0.24.1

### DIFF
--- a/hack/images.yaml
+++ b/hack/images.yaml
@@ -22,6 +22,12 @@ kafka-0.23.0-dev.0:
   - "ghcr.io/banzaicloud/kafka:2.13-3.1.0"
   - "ghcr.io/banzaicloud/jmx-javaagent:0.16.1"
   - "gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0"
+kafka-0.24.1:
+  - "ghcr.io/banzaicloud/kafka-operator:v0.24.1"
+  - "ghcr.io/banzaicloud/cruise-control:2.5.101"
+  - "ghcr.io/banzaicloud/kafka:2.13-3.1.0"
+  - "ghcr.io/banzaicloud/jmx-javaagent:0.16.1"
+  - "gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0"
 zookeeper-0.2.13:
   - "docker.io/pravega/zookeeper-operator:0.2.13"
   - "docker.io/pravega/zookeeper:0.2.13"

--- a/services/kafka-operator/0.24.1/defaults/cm.yaml
+++ b/services/kafka-operator/0.24.1/defaults/cm.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kafka-operator-0.24.1-d2iq-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: |
+    ---
+    certManager:
+      enabled: true
+    crd:
+      enabled: true

--- a/services/kafka-operator/0.24.1/defaults/kustomization.yaml
+++ b/services/kafka-operator/0.24.1/defaults/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml

--- a/services/kafka-operator/0.24.1/kafka-operator.yaml
+++ b/services/kafka-operator/0.24.1/kafka-operator.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: kafka-operator
+  namespace: ${releaseNamespace}
+spec:
+  chart:
+    spec:
+      chart: kafka-operator
+      sourceRef:
+        kind: HelmRepository
+        name: kubernetes-charts.banzaicloud.com
+        namespace: ${workspaceNamespace}
+      version: 0.24.1
+  interval: 15s
+  install:
+    remediation:
+      retries: 30
+    createNamespace: true
+  upgrade:
+    remediation:
+      retries: 30
+  releaseName: kafka-operator
+  valuesFrom:
+    - kind: ConfigMap
+      name: kafka-operator-0.24.1-d2iq-defaults
+  targetNamespace: ${releaseNamespace}

--- a/services/kafka-operator/0.24.1/kustomization.yaml
+++ b/services/kafka-operator/0.24.1/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kafka-operator.yaml
+  - ../../../helm-repositories/banzaicloud

--- a/services/kafka-operator/0.24.1/metadata.yaml
+++ b/services/kafka-operator/0.24.1/metadata.yaml
@@ -1,0 +1,1 @@
+k8sVersionSupport: ">=1.21"


### PR DESCRIPTION
Add a new version of the Kafka operator, v0.24.1. Jira: [D2IQ-97256](https://d2iq.atlassian.net/browse/D2IQ-97256)

Used [new e2e parameter](https://github.com/mesosphere/kommander-e2e/pull/817) to test. `E2E_TEST_PATH=feature/install/suites/kindcluster E2E_MINIMAL_CONFIG=true  E2E_SKIP_CLEANUP=true  E2E_DKP_CATALOG_BRANCH="logg/bump-kafka-0.24.1"  make test.e2e`

[D2IQ-97256]: https://d2iq.atlassian.net/browse/D2IQ-97256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ