### PR TITLE
feat:Bump zookeeper to 0.2.15

### DIFF
--- a/hack/images.yaml
+++ b/hack/images.yaml
@@ -32,3 +32,8 @@ zookeeper-0.2.14:
   - "docker.io/pravega/zookeeper:0.2.14"
   - "docker.io/pravega/zookeeper:0.2.13"
   - "docker.io/lachlanevenson/k8s-kubectl:v1.23.2"
+zookeeper-0.2.15:
+  - "docker.io/pravega/zookeeper-operator:0.2.15"
+  - "docker.io/pravega/zookeeper:0.2.15"
+  - "docker.io/pravega/zookeeper:0.2.14"
+  - "docker.io/lachlanevenson/k8s-kubectl:v1.23.2"

--- a/services/zookeeper-operator/0.2.15/defaults/cm.yaml
+++ b/services/zookeeper-operator/0.2.15/defaults/cm.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zookeeper-operator-0.2.15-d2iq-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: ""

--- a/services/zookeeper-operator/0.2.15/defaults/kustomization.yaml
+++ b/services/zookeeper-operator/0.2.15/defaults/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml

--- a/services/zookeeper-operator/0.2.15/kustomization.yaml
+++ b/services/zookeeper-operator/0.2.15/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - zookeeper-operator.yaml
+  - ../../../helm-repositories/pravega

--- a/services/zookeeper-operator/0.2.15/metadata.yaml
+++ b/services/zookeeper-operator/0.2.15/metadata.yaml
@@ -1,0 +1,1 @@
+k8sVersionSupport: ">=1.21"

--- a/services/zookeeper-operator/0.2.15/zookeeper-operator.yaml
+++ b/services/zookeeper-operator/0.2.15/zookeeper-operator.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: zookeeper-operator
+  namespace: ${releaseNamespace}
+spec:
+  chart:
+    spec:
+      chart: zookeeper-operator
+      sourceRef:
+        kind: HelmRepository
+        name: charts.pravega.io
+        namespace: ${workspaceNamespace}
+      version: 0.2.15
+  interval: 15s
+  install:
+    remediation:
+      retries: 30
+    createNamespace: true
+  upgrade:
+    remediation:
+      retries: 30
+  releaseName: zookeeper-operator
+  valuesFrom:
+    - kind: ConfigMap
+      name: zookeeper-operator-0.2.15-d2iq-defaults
+  targetNamespace: ${releaseNamespace}


### PR DESCRIPTION
Jira: [D2IQ-97257](https://d2iq.atlassian.net/browse/D2IQ-97257)

Bump Zookeeper operator to 0.2.15. Revert to using the upstream image as [our fix has been merged](https://github.com/pravega/zookeeper-operator/issues/428).

Tested using new parameter on E2E tests: `E2E_TEST_PATH=feature/install/suites/kindcluster E2E_MINIMAL_CONFIG=true  E2E_DKP_CATALOG_BRANCH="logg/bump-zookeeper-0.2.15"  make test.e2e`

[D2IQ-97257]: https://d2iq.atlassian.net/browse/D2IQ-97257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ