### PR TITLE
fix(zookeeper): bump kubectl image used for hooks

### DIFF
--- a/hack/images.yaml
+++ b/hack/images.yaml
@@ -42,4 +42,4 @@ zookeeper-0.2.15:
   - "docker.io/pravega/zookeeper-operator:0.2.15"
   - "docker.io/pravega/zookeeper:0.2.15"
   - "docker.io/pravega/zookeeper:0.2.14"
-  - "docker.io/lachlanevenson/k8s-kubectl:v1.23.2"
+  - "docker.io/lachlanevenson/k8s-kubectl:v1.25.4"

--- a/services/zookeeper-operator/0.2.15/defaults/cm.yaml
+++ b/services/zookeeper-operator/0.2.15/defaults/cm.yaml
@@ -5,4 +5,9 @@ metadata:
   name: zookeeper-operator-0.2.15-d2iq-defaults
   namespace: ${releaseNamespace}
 data:
-  values.yaml: ""
+  values.yaml: |
+    ---
+    hooks:
+      image:
+        repository: lachlanevenson/k8s-kubectl
+        tag: v1.25.4


### PR DESCRIPTION
Bumps kubectl images used by the zk operator install/upgrade hooks


should we also bump this in the previous zk operator versions (like 0.2.14)? if customers upgrade the catalog git repo, they would automatically get this new image 🤔. I'm thinking we should never update previously released versions, wdyt?