### PR TITLE
fix(kafka): bump kube-rbac-proxy to v0.14.1

### DIFF
--- a/make/release.mk
+++ b/make/release.mk
@@ -16,7 +16,7 @@ $(BUILD_DIR):
 release.save-images.tar: $(GOJQ_BIN) $(MINDTHEGAP_BIN) $(BUILD_DIR)
 release.save-images.tar:
 	$(call print-target)
-	@$(GOJQ_BIN) -r --yaml-input '.|flatten|sort|.[]' hack/images.yaml > $(CATALOG_IMAGES_TXT)
+	@$(GOJQ_BIN) -r --yaml-input '.|flatten|sort|unique|.[]' hack/images.yaml > $(CATALOG_IMAGES_TXT)
 	@$(MINDTHEGAP_BIN) create image-bundle --platform linux/amd64 --images-file $(CATALOG_IMAGES_TXT) --output-file $(IMAGE_TAR_FILE)
 	@ls -latrh $(IMAGE_TAR_FILE)
 

--- a/services/kafka-operator/0.24.1/defaults/cm.yaml
+++ b/services/kafka-operator/0.24.1/defaults/cm.yaml
@@ -11,3 +11,8 @@ data:
       enabled: true
     crd:
       enabled: true
+    prometheusMetrics:
+      authProxy:
+        image:
+          repository: gcr.io/kubebuilder/kube-rbac-proxy
+          tag: v0.14.1


### PR DESCRIPTION
Bumps kube-rbac-proxy to v0.14.1 