### PR TITLE
feat: limit containers send to CVE reporter

### DIFF
--- a/hack/cve/whitelist.yaml
+++ b/hack/cve/whitelist.yaml
@@ -1,0 +1,7 @@
+# List of applications that should be reported to CVE reporter. Apps in this list
+# must match keys in /hack/images.yaml file.
+- zookeeper-0.2.14
+- zookeeper-0.2.15
+- spark-1.1.17
+- kafka-0.23.0-dev.0
+- kafka-0.25.1

--- a/make/release.mk
+++ b/make/release.mk
@@ -25,7 +25,9 @@ cve-reporter.push-images: $(GOJQ_BIN)
 cve-reporter.push-images: CVE_REPORTER_KOMMANDER_VERSION ?= main
 cve-reporter.push-images:
 	$(call print-target)
-	@$(GOJQ_BIN) -r --yaml-input '.|flatten|sort|unique' hack/images.yaml > $(CATALOG_IMAGES_TXT)
+	$(GOJQ_BIN) -r --yaml-input \
+		--argjson whitelist '$(shell $(GOJQ_BIN) -rc --yaml-input '.' hack/cve/whitelist.yaml)' \
+		'with_entries( select( .key | IN($$whitelist[]) ) ) | flatten | sort | unique' hack/images.yaml > $(CATALOG_IMAGES_TXT)
 	TMP_IMAGES_JSON=$$(mktemp) && \
 	$(GOJQ_BIN) --arg DKP_CATALOG_VERSION $(CVE_REPORTER_KOMMANDER_VERSION) \
 		-r -f ./hack/cve/convert-images-json.jq $(CATALOG_IMAGES_TXT) > $$TMP_IMAGES_JSON && \


### PR DESCRIPTION
Allows control which containers are sent to CVE reporter by app.