### PR TITLE
ci: Add docker credentials

### DIFF
--- a/.github/workflows/release-airgap-artifacts.yaml
+++ b/.github/workflows/release-airgap-artifacts.yaml
@@ -13,6 +13,11 @@ jobs:
     runs-on:
       - self-hosted
       - medium
+
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_READ_WRITE_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_READ_WRITE_PASSWORD }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/release-airgap-artifacts.yaml
+++ b/.github/workflows/release-airgap-artifacts.yaml
@@ -14,10 +14,6 @@ jobs:
       - self-hosted
       - medium
 
-    env:
-      DOCKER_USERNAME: ${{ secrets.DOCKER_READ_WRITE_USERNAME }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_READ_WRITE_PASSWORD }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -34,6 +30,12 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/dkp-catalog-applications
           aws-region: us-west-2
+
+      - name: Login to Docker Hub and Nexus
+        uses: mesosphere/workflow-db/actions/docker/login@main
+        with:
+          username: ${{ secrets.NEXUS_USERNAME }}
+          password: ${{ secrets.NEXUS_PASSWORD }}
 
       - name: make release.chart-bundle
         run: make ci.docker.run GOOS=linux GOARCH=amd64 RUN_WHAT="make release.chart-bundle"

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,7 @@ REPO_ROOT := $(CURDIR)
 INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 
 export GOPRIVATE ?= github.com/mesosphere
-export GITHUB_ORG ?= mesosphere
-export GITHUB_REPOSITORY ?= dkp-catalog-applications
+export GITHUB_REPOSITORY ?= mesosphere/dkp-catalog-applications
 export GOBIN := $(REPO_ROOT)/bin/$(GOOS)/$(GOARCH)
 export PATH := $(GOBIN):$(PATH)
 GOARCH ?= $(shell go env GOARCH)

--- a/make/ci.mk
+++ b/make/ci.mk
@@ -2,9 +2,9 @@ CI_DOCKERFILE ?= $(REPO_ROOT)/Dockerfile.ci
 
 ifneq ($(wildcard $(CI_DOCKERFILE)),)
 CI_DOCKER_TAG ?= $(shell (cat $(CI_DOCKERFILE) $(CI_DOCKER_EXTRA_FILES) \
-                         $(if $(CI_DOCKER_BUILD_ARGS),&& echo $(CI_DOCKER_BUILD_ARGS))) \
-                         | shasum | awk '{ print $$1 }')
-CI_DOCKER_IMG ?= $(GITHUB_ORG)/$(GITHUB_REPOSITORY)-ci:$(CI_DOCKER_TAG)
+						 $(if $(CI_DOCKER_BUILD_ARGS),&& echo $(CI_DOCKER_BUILD_ARGS))) \
+						 | shasum | awk '{ print $$1 }')
+CI_DOCKER_IMG ?= $(GITHUB_REPOSITORY)-ci:$(CI_DOCKER_TAG)
 
 export GOLANG_VERSION ?= 1.19.1
 DOCKER_VERSION ?= 20.10.7
@@ -46,7 +46,7 @@ ci.docker.run: RUN_WHAT ?=
 ci.docker.run: ci.docker.ensure ; $(info $(M) Runs the build in the CI Docker image)
 	docker run --rm -i$(if $(RUN_WHAT),,$(if $(INTERACTIVE),t)) \
 		-v $(REPO_ROOT):$(REPO_ROOT) \
- 		-w $(REPO_ROOT) \
+		-w $(REPO_ROOT) \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v /etc/docker/certs.d:/etc/docker/certs.d \
 		$(if $(AWS_REGION),-e AWS_REGION=$(AWS_REGION)) \


### PR DESCRIPTION
Let's fix the following problem:

```
(docker image inspect mesosphere/mesosphere/dkp-catalog-applications-ci:73fbedfa0a22d88a7b64f7c5d728706a8c7e94d4 &>/dev/null && echo 'mesosphere/mesosphere/dkp-catalog-applications-ci:73fbedfa0a22d88a7b64f7c5d728706a8c7e94d4 already exists - skipping image build' ) || \
    docker pull mesosphere/mesosphere/dkp-catalog-applications-ci:73fbedfa0a22d88a7b64f7c5d728706a8c7e94d4 || \
    make ci.docker.build
Error response from daemon: pull access denied for mesosphere/mesosphere/dkp-catalog-applications-ci, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```


https://github.com/mesosphere/dkp-catalog-applications/actions/runs/6242181447/job/16958359076#step:7:18


Also, changing the value of `GITHUB_REPOSITORY` as it is a variable provided by the GHA env: https://docs.github.com/en/actions/learn-github-actions/variables