### PR TITLE
ci: Don't use workflow-db

### DIFF
--- a/.github/workflows/release-airgap-artifacts.yaml
+++ b/.github/workflows/release-airgap-artifacts.yaml
@@ -31,9 +31,10 @@ jobs:
           role-to-assume: arn:aws:iam::999867407951:role/dkp-catalog-applications
           aws-region: us-west-2
 
-      - name: Login to Docker Hub and Nexus
-        uses: mesosphere/workflow-db/actions/docker/login@main
+      - name: Login to Nexus
+        uses: docker/login-action@v3
         with:
+          registry: ${{ secrets.NEXUS_REGISTRY }}
           username: ${{ secrets.NEXUS_USERNAME }}
           password: ${{ secrets.NEXUS_PASSWORD }}
 


### PR DESCRIPTION
It seems we cannot use a private gha.
