### PR TITLE
chore: bundle a newer Kafka image

### DIFF
--- a/hack/images.yaml
+++ b/hack/images.yaml
@@ -1,7 +1,7 @@
 kafka-0.25.1:
   - "ghcr.io/banzaicloud/kafka-operator:v0.25.1"
   - "ghcr.io/banzaicloud/cruise-control:2.5.123"
-  - "ghcr.io/banzaicloud/kafka:2.13-3.1.2"
+  - "ghcr.io/banzaicloud/kafka:2.13-3.4.1"
   - "ghcr.io/banzaicloud/jmx-javaagent:0.16.1"
   - "gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1"
 zookeeper-0.2.15:

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -40,7 +40,7 @@ resources:
         ref: ${image_tag}
         license_path: LICENSE
         notice_path: NOTICE
-  - container_image: ghcr.io/banzaicloud/kafka:2.13-3.1.2
+  - container_image: ghcr.io/banzaicloud/kafka:2.13-3.4.1
     sources:
       - url: https://github.com/banzaicloud/docker-kafka
         ref: ${image_tag}

--- a/make/release.mk
+++ b/make/release.mk
@@ -32,7 +32,7 @@ release.whitelisted-images:
 
 .PHONY: cve-reporter.push-images
 cve-reporter.push-images: $(GOJQ_BIN)
-cve-reporter.push-images: release.whitelisted-images 
+cve-reporter.push-images: release.whitelisted-images
 cve-reporter.push-images: CVE_REPORTER_PROJECT_VERSION ?= main
 cve-reporter.push-images:
 	$(call print-target)


### PR DESCRIPTION
This removes the vulnerable Kafka 3.1.2 image (one used by default by `kafka-operator`) from the air-gapped bundle and adds the oldest image not containing relevant CVEs to the bundle.

The side effect is that in airgapped settings `kafka-operator` will not be able to handle KafkaClusters that do not specify an image explicitly (which is not the recommended way to use it and not something we want to continue to support). 