### PR TITLE
chore: switch zookeeper-operator to images from our fork

### DIFF
--- a/hack/images.yaml
+++ b/hack/images.yaml
@@ -5,6 +5,6 @@ kafka-0.25.1:
   - "ghcr.io/banzaicloud/jmx-javaagent:0.16.1"
   - "gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1"
 zookeeper-0.2.15-dkp.1:
-  - "docker.io/pravega/zookeeper-operator:0.2.15"
-  - "docker.io/pravega/zookeeper:0.2.15"
+  - "ghcr.io/mesosphere/zookeeper-operator:0.2.15-d2iq"
+  - "ghcr.io/mesosphere/zookeeper:0.2.15-d2iq"
   - "docker.io/bitnami/kubectl:1.27.6"

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -1,14 +1,14 @@
 ignore:
   - docker.io/bitnami/kubectl:1.27.6
 resources:
-  - container_image: docker.io/pravega/zookeeper-operator:0.2.15
+  - container_image: ghcr.io/mesosphere/zookeeper-operator:0.2.15-d2iq
     sources:
-      - url: https://github.com/pravega/zookeeper-operator
+      - url: https://github.com/mesosphere/zookeeper-operator
         ref: v${image_tag}
         license_path: LICENSE
-  - container_image: docker.io/pravega/zookeeper:0.2.15
+  - container_image: ghcr.io/mesosphere/zookeeper:0.2.15-d2iq
     sources:
-      - url: https://github.com/pravega/zookeeper-operator
+      - url: https://github.com/mesosphere/zookeeper-operator
         ref: v${image_tag}
         license_path: LICENSE
   - container_image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1

--- a/services/zookeeper-operator/0.2.15-dkp.1/defaults/cm.yaml
+++ b/services/zookeeper-operator/0.2.15-dkp.1/defaults/cm.yaml
@@ -7,6 +7,9 @@ metadata:
 data:
   values.yaml: |
     ---
+    image:
+      repository: ghcr.io/mesosphere/zookeeper-operator
+      tag: 0.2.15-d2iq
     hooks:
       image:
         repository: bitnami/kubectl


### PR DESCRIPTION
**Testing**
 Did an upgrade from 0.2.13 with a running ZK cluster: first of the app, then of the cluster.