### PR TITLE
build: Add daily dev tag job

### DIFF
--- a/.github/workflows/create-dev-tag.yaml
+++ b/.github/workflows/create-dev-tag.yaml
@@ -1,0 +1,74 @@
+name: Create Development Tag
+
+on:
+  workflow_dispatch:
+
+  schedule:
+    - cron: '5 3 * * *'
+
+env:
+  GOWORK: off
+  GOPRIVATE: github.com/mesosphere
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  generate-matrix:
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+    runs-on:
+    - self-hosted
+    - small
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate tag
+        id: set-matrix
+        run: |
+          export GITHUB_REPOSITORY="dkp-catalog-applications"
+          OUT=$(make repo.supported-branches | tail -n 1)
+          echo "matrix=$OUT" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.MESOSPHERECI_USER_TOKEN }}
+
+  create-dev-tag:
+    needs: generate-matrix
+
+    runs-on:
+    - self-hosted
+    - small
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+          depth: 0
+
+      - name: Generate tag
+        run: |
+          # Overriding a variable that causes a conflict in legacy
+          # versions of gh-dkp
+          export GITHUB_REPOSITORY="dkp-catalog-applications"
+          OUT=$(make repo.dev.tag)
+          echo "TAG=$(echo ${OUT##* })" >> $GITHUB_ENV
+        env:
+          GITHUB_TOKEN: ${{ secrets.MESOSPHERECI_USER_TOKEN }}
+
+      - name: Create tag
+        run: |
+          git config --global user.email "ci-mergebot@d2iq.com"
+          git config --global user.name "ci-mergebot"
+          git tag -m "${{ env.TAG }}" ${{ env.TAG }}
+
+      - name: Push tag
+        run: git push --force --tags origin ${{ env.TAG }}

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ include make/ci.mk
 include make/validate.mk
 include make/release.mk
 include make/tools.mk
+include make/repo.mk
 
 .PHONY: pre-commit
 pre-commit: ## Runs pre-commit on all files

--- a/make/repo.mk
+++ b/make/repo.mk
@@ -1,0 +1,8 @@
+.PHONY: repo.dev.tag
+repo.dev.tag: ## Returns development tag
+repo.dev.tag: gh-dkp
+	gh dkp generate dev-version --repository-owner $(GITHUB_ORG) --repository-name $(GITHUB_REPOSITORY)
+
+.PHONY: repo.supported-branches
+repo.supported-branches: gh-dkp
+	gh dkp generate dev-versions --json | jq --raw-output --compact-output "[.releases[] | .branch_name]"

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -32,3 +32,7 @@ kommander-cli:
 	go install golang.org/dl/go1.19@latest
 	go1.19 download
 	CGO_ENABLED=0 go1.19 install github.com/mesosphere/kommander-cli/v2@$(KOMMANDER_CLI_VERSION)
+
+.PHONY: gh-dkp
+gh-dkp: ; $(info $(M) installing $*)
+	gh extensions install mesosphere/gh-dkp || gh dkp -h


### PR DESCRIPTION
Now that we are pulling artifacts from tagged releases from dkp-catalog-applications (instead of `main`) to embed in bootstrapper, we need to cut daily dev tags. Looks like previously we were not cutting daily releases in this repo.