### PR TITLE
fix: check-licenses failure (2.12)

### DIFF
--- a/.github/workflows/check-licenses.yaml
+++ b/.github/workflows/check-licenses.yaml
@@ -6,7 +6,7 @@ on:
 
 env:
   # see release.mk
-  IMAGES_TXT_PATH: _build/dkp_catalog_images_whitelisted.txt
+  IMAGES_TXT_PATH: _build/nkp_catalog_images_whitelisted.txt
 
 jobs:
   check-license-yaml:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release-2.12`:
 - [fix: check-licenses failure (#146)](https://github.com/mesosphere/dkp-catalog-applications/pull/146)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)