### PR TITLE
ci: bump dockerfile golang version

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -6,13 +6,16 @@ RUN apt-get update && apt-get install -y \
     bzip2 \
     git \
     build-essential \
-    python-dev \
+    python-dev-is-python3 \
     python3 \
     python3-pip \
     shellcheck \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --upgrade pre-commit yamale yamllint awscli gitlint
+# The sole purpose of docker image is to run CI jobs and thus we never have more than one version of python and
+# it is fine to break any packages installed by apt with same name.
+# If `--break-system-packages` is removed, we need to use virtual env. (See related https://peps.python.org/pep-0668/)
+RUN pip3 install --break-system-packages --upgrade pre-commit yamale yamllint awscli gitlint
 
 ARG DOCKER_VERSION
 RUN curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz | \

--- a/make/ci.mk
+++ b/make/ci.mk
@@ -6,7 +6,7 @@ CI_DOCKER_TAG ?= $(shell (cat $(CI_DOCKERFILE) $(CI_DOCKER_EXTRA_FILES) \
                          | shasum | awk '{ print $$1 }')
 CI_DOCKER_IMG ?= $(GITHUB_ORG)/$(GITHUB_REPOSITORY)-ci:$(CI_DOCKER_TAG)
 
-export GOLANG_VERSION ?= 1.19.1
+export GOLANG_VERSION ?= 1.23.0
 DOCKER_VERSION ?= 20.10.7
 
 .PHONY: dockerauth

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -29,9 +29,7 @@ $(GOJQ_BIN):
 .PHONY: kommander-cli
 kommander-cli:
 	$(call print-target)
-	go install golang.org/dl/go1.19@latest
-	go1.19 download
-	CGO_ENABLED=0 go1.19 install github.com/mesosphere/kommander-cli/v2@$(KOMMANDER_CLI_VERSION)
+	CGO_ENABLED=0 go install github.com/mesosphere/kommander-cli/v2@$(KOMMANDER_CLI_VERSION)
 
 .PHONY: gh-dkp
 gh-dkp: ; $(info $(M) installing $*)


### PR DESCRIPTION
Release tooling is failing with https://github.com/mesosphere/dkp-catalog-applications/actions/runs/11078609251/job/30787951147 after bumping kommander cli go version