### PR TITLE
fix: use mesosphere stable charts repo for kafka-operator (2.12)

### DIFF
--- a/helm-repositories/banzaicloud/banzaicloud.yaml
+++ b/helm-repositories/banzaicloud/banzaicloud.yaml
@@ -7,5 +7,5 @@ metadata:
   labels:
     kommander.d2iq.io/dkp-airgapped: supported
 spec:
-  url: "${helmMirrorURL:=https://kubernetes-charts.banzaicloud.com}"
+  url: "${helmMirrorURL:=https://mesosphere.github.io/charts/stable}"
   interval: 10m

--- a/make/release.mk
+++ b/make/release.mk
@@ -57,8 +57,10 @@ endif
 release.chart-bundle: kommander-cli
 	$(call print-target)
 	echo "Building charts bundle from nkp-catalog-applications repository: "
+	# skip kafka-operator charts for unsupported versions
 	$(KOMMANDER_CLI_BIN) create chart-bundle \
 		--catalog-repository $(REPO_ROOT) \
+		--skip-charts kafka-operator:0.20.0,kafka-operator:0.20.2,kafka-operator:0.23.0-dev.0 \
 		--output $(CHART_BUNDLE)
 
 .PHONY: release.s3


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release-2.12`:
 - [fix: use mesosphere stable charts repo for kafka-operator (#157)](https://github.com/mesosphere/dkp-catalog-applications/pull/157)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)