### PR TITLE
fix: use mesosphere stable charts repo for kafka-operator (2.7)

### DIFF
--- a/.bloodhound.yml
+++ b/.bloodhound.yml
@@ -8,8 +8,8 @@ k8s_versions:
 
 # paths to load (in that order)
 paths:
-  - helm-repositories
-  - services
+  - services/zookeeper-operator
+  - services/kafka-operator/0.25.1
 
 # use strict validation (reject unknown fields in resources)
 strict: true

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -6,13 +6,13 @@ RUN apt-get update && apt-get install -y \
     bzip2 \
     git \
     build-essential \
-    python-dev \
+    python-dev-is-python3 \
     python3 \
     python3-pip \
     shellcheck \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --upgrade pre-commit yamale yamllint awscli gitlint
+RUN pip3 install --break-system-packages --upgrade pre-commit yamale yamllint awscli gitlint
 
 ARG DOCKER_VERSION
 RUN curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz | \

--- a/helm-repositories/banzaicloud/banzaicloud.yaml
+++ b/helm-repositories/banzaicloud/banzaicloud.yaml
@@ -7,5 +7,5 @@ metadata:
   labels:
     kommander.d2iq.io/dkp-airgapped: supported
 spec:
-  url: "${helmMirrorURL:=https://kubernetes-charts.banzaicloud.com}"
+  url: "${helmMirrorURL:=https://mesosphere.github.io/charts/stable}"
   interval: 10m

--- a/make/ci.mk
+++ b/make/ci.mk
@@ -6,7 +6,7 @@ CI_DOCKER_TAG ?= $(shell (cat $(CI_DOCKERFILE) $(CI_DOCKER_EXTRA_FILES) \
                          | shasum | awk '{ print $$1 }')
 CI_DOCKER_IMG ?= $(GITHUB_ORG)/$(GITHUB_REPOSITORY)-ci:$(CI_DOCKER_TAG)
 
-export GOLANG_VERSION ?= 1.19.1
+export GOLANG_VERSION ?= 1.23.2
 DOCKER_VERSION ?= 20.10.7
 
 .PHONY: dockerauth

--- a/make/release.mk
+++ b/make/release.mk
@@ -56,8 +56,10 @@ endif
 release.chart-bundle: kommander-cli
 	$(call print-target)
 	echo "Building charts bundle from dkp-catalog-applications repository: "
+	# skip kafka-operator charts for unsupported versions
 	$(KOMMANDER_CLI_BIN) create chart-bundle \
 		--catalog-repository $(REPO_ROOT) \
+		--skip-charts kafka-operator:0.20.0,kafka-operator:0.20.2,kafka-operator:0.23.0-dev.0 \
 		--output $(CHART_BUNDLE)
 
 .PHONY: release.s3

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -29,9 +29,7 @@ $(GOJQ_BIN):
 .PHONY: kommander-cli
 kommander-cli:
 	$(call print-target)
-	go install golang.org/dl/go1.19@latest
-	go1.19 download
-	CGO_ENABLED=0 go1.19 install github.com/mesosphere/kommander-cli/v2@$(KOMMANDER_CLI_VERSION)
+	CGO_ENABLED=0 go install github.com/mesosphere/kommander-cli/v2@$(KOMMANDER_CLI_VERSION)
 
 .PHONY: gh-dkp
 gh-dkp: ; $(info $(M) installing $*)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release-2.7`:
 - [fix: use mesosphere stable charts repo for kafka-operator (#157)](https://github.com/mesosphere/dkp-catalog-applications/pull/157)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)