### PR TITLE
chore(kafka-operator): bump kube-oidc-proxy

### DIFF
--- a/hack/cve/whitelist.yaml
+++ b/hack/cve/whitelist.yaml
@@ -1,4 +1,4 @@
 # List of applications that should be reported to CVE reporter. Apps in this list
 # must match keys in /hack/images.yaml file.
 - zookeeper-0.2.16-dkp.3
-- kafka-0.25.2
+- kafka-0.25.3

--- a/hack/images.yaml
+++ b/hack/images.yaml
@@ -1,9 +1,9 @@
-kafka-0.25.2:
+kafka-0.25.3:
   - "ghcr.io/banzaicloud/kafka-operator:v0.25.1"
   - "ghcr.io/mesosphere/cruise-control:2.5.139"
   - "ghcr.io/mesosphere/dkp-container-images/ghcr.io/banzaicloud/kafka:2.13-3.4.1-d2iq.1"
   - "ghcr.io/mesosphere/jmx-javaagent:0.18.0"
-  - "gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1"
+  - "quay.io/brancz/kube-rbac-proxy:v0.18.1"
 zookeeper-0.2.16-dkp.3:
   - "ghcr.io/mesosphere/zookeeper-operator:0.2.15-d2iq"
   - "ghcr.io/mesosphere/zookeeper:0.2.15-d2iq"

--- a/licenses.d2iq.yaml
+++ b/licenses.d2iq.yaml
@@ -9,7 +9,7 @@ resources:
       - url: https://github.com/mesosphere/zookeeper-operator
         ref: v${image_tag}
         license_path: LICENSE
-  - container_image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
+  - container_image: quay.io/brancz/kube-rbac-proxy:v0.18.1
     sources:
       - url: https://github.com/brancz/kube-rbac-proxy
         ref: ${image_tag}

--- a/services/kafka-operator/0.25.3/defaults/cm.yaml
+++ b/services/kafka-operator/0.25.3/defaults/cm.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kafka-operator-0.25.3-d2iq-defaults
+  namespace: ${releaseNamespace}
+data:
+  values.yaml: |
+    ---
+    certManager:
+      enabled: true
+    crd:
+      enabled: true
+    prometheusMetrics:
+      authProxy:
+        image:
+          repository: quay.io/brancz/kube-rbac-proxy
+          tag: v0.18.1

--- a/services/kafka-operator/0.25.3/defaults/kustomization.yaml
+++ b/services/kafka-operator/0.25.3/defaults/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml

--- a/services/kafka-operator/0.25.3/kafka-operator.yaml
+++ b/services/kafka-operator/0.25.3/kafka-operator.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: kafka-operator
+  namespace: ${releaseNamespace}
+spec:
+  chart:
+    spec:
+      chart: kafka-operator
+      sourceRef:
+        kind: HelmRepository
+        name: kubernetes-charts.banzaicloud.com
+        namespace: ${workspaceNamespace}
+      version: 0.25.1
+  interval: 15s
+  install:
+    remediation:
+      retries: 30
+    createNamespace: true
+  upgrade:
+    remediation:
+      retries: 30
+  releaseName: kafka-operator
+  valuesFrom:
+    - kind: ConfigMap
+      name: kafka-operator-0.25.3-d2iq-defaults
+  targetNamespace: ${releaseNamespace}

--- a/services/kafka-operator/0.25.3/kustomization.yaml
+++ b/services/kafka-operator/0.25.3/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kafka-operator.yaml
+  - ../../../helm-repositories/banzaicloud

--- a/services/kafka-operator/0.25.3/metadata.yaml
+++ b/services/kafka-operator/0.25.3/metadata.yaml
@@ -1,0 +1,1 @@
+k8sVersionSupport: ">=1.21"


### PR DESCRIPTION
e2e https://github.com/mesosphere/kommander-e2e/actions/runs/11328987778

Test run:

```
Kommander installation verifying kommander installation and catalog apps Catalog Application should install cleanly: kafka-operator, version 0.25.3, k8s constraint >=1.21 [install, catalog-apps]
/runner/_work/kommander-e2e/kommander-e2e/test/e2e/components/catalogapps/catalogapps.go:110
  > Enter [BeforeEach] Catalog Application @ 10/14/24 15:13:11.569
  < Exit [BeforeEach] Catalog Application @ 10/14/24 15:13:11.57 (0s)
  > Enter [It] kafka-operator, version 0.25.3, k8s constraint >=1.21 @ 10/14/24 15:13:11.57
  STEP: App definition should be created @ 10/14/24 15:13:11.57
  END STEP: App definition should be created @ 10/14/24 15:13:11.591 (21ms)
  STEP: create AppDeployment @ 10/14/24 15:13:11.591
  END STEP: create AppDeployment @ 10/14/24 15:13:11.617 (26ms)
  STEP: HelmReleaseStatus kafka-operator (version: 0.25.1) should become ready @ 10/14/24 15:13:11.617
 • Helm Release zookeeper-operator returned NOT READY status !!!
 • Helm Release zookeeper-operator returned NOT READY status !!!
 ✓ Helm Release kafka-operator is READY
 ✓ Helm Release kafka-operator is READY
  END STEP: HelmReleaseStatus kafka-operator (version: 0.25.1) should become ready @ 10/14/24 15:13:54.237 (42.62s)
  STEP: deploy Zookeeper Operator @ 10/14/24 15:13:54.238
  END STEP: deploy Zookeeper Operator @ 10/14/24 15:13:54.264 (27ms)
  STEP: HelmRelease should become ready @ 10/14/24 15:13:54.265
 ✓ Helm Release zookeeper-operator is READY
 ✓ Helm Release zookeeper-operator is READY
  END STEP: HelmRelease should become ready @ 10/14/24 15:15:23.56 (1m29.296s)
  STEP: create ZookeeperCluster @ 10/14/24 15:15:23.561
  END STEP: create ZookeeperCluster @ 10/14/24 15:15:23.582 (22ms)
  STEP: ZookeeperCluster should deploy with no errors @ 10/14/24 15:15:23.583
W1014 15:16:30.113745   33586 warnings.go:70] v2beta1 HelmRelease is deprecated, upgrade to v2beta2
  END STEP: ZookeeperCluster should deploy with no errors @ 10/14/24 15:19:26.063 (4m2.48s)
  STEP: create KafkaCluster @ 10/14/24 15:19:26.063
  END STEP: create KafkaCluster @ 10/14/24 15:19:26.121 (58ms)
  STEP: KafkaCluster should deploy with no errors @ 10/14/24 15:19:26.121
  END STEP: KafkaCluster should deploy with no errors @ 10/14/24 15:20:22.202 (56.08s)
  STEP: delete KafkaCluster @ 10/14/24 15:20:22.202
  END STEP: delete KafkaCluster @ 10/14/24 15:20:22.246 (44ms)
  STEP: Delete ZookeeperCluster @ 10/14/24 15:20:22.246
  END STEP: Delete ZookeeperCluster @ 10/14/24 15:20:22.27 (24ms)
  STEP: Delete Zookeeper Operator deployment @ 10/14/24 15:20:22.27
  END STEP: Delete Zookeeper Operator deployment @ 10/14/24 15:20:22.293 (22ms)
  STEP: HelmRelease should be removed @ 10/14/24 15:20:22.293
W1014 15:20:32.837107   33586 warnings.go:70] v2beta1 HelmRelease is deprecated, upgrade to v2beta2
  END STEP: HelmRelease should be removed @ 10/14/24 15:20:42.684 (20.391s)
  STEP: delete AppDeployment @ 10/14/24 15:20:42.685
  END STEP: delete AppDeployment @ 10/14/24 15:20:42.805 (119ms)
  STEP: HelmReleaseStatus kafka-operator (version: 0.25.1) should be removed @ 10/14/24 15:20:42.805
 • Helm Release zookeeper-operator returned NOT READY status !!!
 • Helm Release zookeeper-operator returned NOT READY status !!!
 • Helm Release kafka-operator returned NOT READY status !!!
 • Helm Release kafka-operator returned NOT READY status !!!
  END STEP: HelmReleaseStatus kafka-operator (version: 0.25.1) should be removed @ 10/14/24 15:21:53.696 (1m10.891s)
  STEP: AppDeployment should be removed @ 10/14/24 15:21:53.696
  END STEP: AppDeployment should be removed @ 10/14/24 15:21:53.714 (17ms)
  < Exit [It] kafka-operator, version 0.25.3, k8s constraint >=1.21 @ 10/14/24 15:21:53.714 (8m42.144s)
  > Enter [DeferCleanup (Each)] Catalog Application @ 10/14/24 15:21:53.714
  < Exit [DeferCleanup (Each)] Catalog Application @ 10/14/24 15:21:53.715 (0s)
```