### PR TITLE
feat: update k8s version 1.33.0 to dkp-catalog

### DIFF
--- a/.bloodhound.yml
+++ b/.bloodhound.yml
@@ -4,6 +4,7 @@ k8s_versions:
   - 1.30.5
   - 1.31.4
   - 1.32.2
+  - 1.33.0
 
 # paths to load (in that order)
 paths:

--- a/.bloodhound.yml
+++ b/.bloodhound.yml
@@ -4,6 +4,7 @@ k8s_versions:
   - 1.30.5
   - 1.31.4
   - 1.32.2
+  - 1.32.3
   - 1.33.0
 
 # paths to load (in that order)

--- a/make/ci.mk
+++ b/make/ci.mk
@@ -6,7 +6,7 @@ CI_DOCKER_TAG ?= $(shell (cat $(CI_DOCKERFILE) $(CI_DOCKER_EXTRA_FILES) \
                          | shasum | awk '{ print $$1 }')
 CI_DOCKER_IMG ?= $(GITHUB_ORG)/$(GITHUB_REPOSITORY)-ci:$(CI_DOCKER_TAG)
 
-export GOLANG_VERSION ?= 1.23.0
+export GOLANG_VERSION ?= 1.24.2
 DOCKER_VERSION ?= 20.10.7
 
 .PHONY: dockerauth


### PR DESCRIPTION
What problem does this PR solve?:
bumping 1.33.0 in dk-catalog for checking incompatible resources

Which issue(s) does this PR fix?:

https://jira.nutanix.com/browse/NCN-106610